### PR TITLE
Fix AActor 상속하는 Actor Duplicate Error

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Object.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Object.h
@@ -47,6 +47,8 @@ public:
     FName GetFName() const { return NamePrivate; }
     FString GetName() const { return NamePrivate.ToString(); }
 
+    void SetFName(const FString& InName) { NamePrivate = InName; }
+
     uint32 GetUUID() const { return UUID; }
     uint32 GetInternalIndex() const { return InternalIndex; }
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/AmbientLightActor.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/AmbientLightActor.cpp
@@ -19,3 +19,14 @@ AAmbientLight::AAmbientLight()
 AAmbientLight::~AAmbientLight()
 {
 }
+
+UObject* AAmbientLight::Duplicate(UObject* InOuter)
+{
+    ThisClass* NewActor = Cast<ThisClass>(Super::Duplicate(InOuter));
+    
+    NewActor->AmbientLightComponent = NewActor->GetComponentByFName<UAmbientLightComponent>(AmbientLightComponent->GetFName());
+    NewActor->BillboardComponent = NewActor->GetComponentByFName<UBillboardComponent>(BillboardComponent->GetFName());
+
+
+    return NewActor;
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/AmbientLightActor.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/AmbientLightActor.h
@@ -6,7 +6,8 @@ class AAmbientLight : public ALight
 public:
     AAmbientLight();
     virtual ~AAmbientLight();
-
+    UObject* Duplicate(UObject* InOuter) override;
+    
 protected:
     UPROPERTY
     (UAmbientLightComponent*, AmbientLightComponent, = nullptr);

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/Cube.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/Cube.cpp
@@ -3,20 +3,7 @@
 
 #include "Engine/FLoaderOBJ.h"
 
-#include "GameFramework/Actor.h"
-
 ACube::ACube()
 {
-    // Begin Test
-    //StaticMeshComponent->SetStaticMesh(FManagerOBJ::GetStaticMesh(L"Contents/helloBlender.obj"));
     StaticMeshComponent->SetStaticMesh(FManagerOBJ::GetStaticMesh(L"Contents/Reference/Reference.obj"));
-    // End Test
-}
-
-void ACube::Tick(float DeltaTime)
-{
-    Super::Tick(DeltaTime);
-
-    //SetActorRotation(GetActorRotation() + FRotator(0, 0, 1));
-
 }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/Cube.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/Cube.h
@@ -5,13 +5,7 @@
 class ACube : public AStaticMeshActor
 {
     DECLARE_CLASS(ACube, AStaticMeshActor)
-
 public:
     ACube();
-
-    virtual void Tick(float DeltaTime) override;
-
-    
-
 };
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/DirectionalLightActor.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/DirectionalLightActor.cpp
@@ -18,6 +18,16 @@ ADirectionalLight::~ADirectionalLight()
 {
 }
 
+UObject* ADirectionalLight::Duplicate(UObject* InOuter)
+{
+    ThisClass* NewActor = Cast<ThisClass>(Super::Duplicate(InOuter));
+    
+    NewActor->DirectionalLightComponent = NewActor->GetComponentByFName<UDirectionalLightComponent>(DirectionalLightComponent->GetFName());
+    NewActor->BillboardComponent = NewActor->GetComponentByFName<UBillboardComponent>(BillboardComponent->GetFName());
+
+    return NewActor;
+}
+
 void ADirectionalLight::SetIntensity(float Intensity)
 {
     if (DirectionalLightComponent)

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/DirectionalLightActor.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/DirectionalLightActor.h
@@ -8,6 +8,8 @@ public:
     ADirectionalLight();
     virtual ~ADirectionalLight();
 
+    UObject* Duplicate(UObject* InOuter) override;
+    
 public:
     void SetIntensity(float Intensity);
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/FireballActor.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/FireballActor.cpp
@@ -10,10 +10,8 @@
 AFireballActor::AFireballActor()
 {
     FManagerOBJ::CreateStaticMesh("Contents/Sphere.obj");
-
-
-    SphereComp = AddComponent<USphereComp>("USphereComp_0");
     
+    SphereComp = AddComponent<USphereComp>("USphereComp_0");
     SphereComp->SetStaticMesh(FManagerOBJ::GetStaticMesh(L"Contents/Sphere.obj"));
   
     PointLightComponent = AddComponent<UPointLightComponent>("UPointLightComponent_0");
@@ -32,6 +30,17 @@ AFireballActor::AFireballActor()
 
 AFireballActor::~AFireballActor()
 {
+}
+
+UObject* AFireballActor::Duplicate(UObject* InOuter)
+{
+    ThisClass* NewActor = Cast<ThisClass>(Super::Duplicate(InOuter));
+
+    NewActor->SphereComp = NewActor->GetComponentByFName<USphereComp>(SphereComp->GetFName());
+    NewActor->PointLightComponent = NewActor->GetComponentByFName<UPointLightComponent>(PointLightComponent->GetFName());
+    NewActor->ProjectileMovementComponent = NewActor->GetComponentByFName<UProjectileMovementComponent>(ProjectileMovementComponent->GetFName());
+
+    return NewActor;
 }
 
 void AFireballActor::BeginPlay()

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/FireballActor.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/FireballActor.h
@@ -11,6 +11,9 @@ class AFireballActor : public AActor
 public:
     AFireballActor();
     virtual ~AFireballActor();
+    
+    UObject* Duplicate(UObject* InOuter) override;
+    
     virtual void BeginPlay() override;
 
 protected:

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/HeightFogActor.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/HeightFogActor.cpp
@@ -6,3 +6,11 @@ AHeightFogActor::AHeightFogActor()
 {
     HeightFogComponent = AddComponent<UHeightFogComponent>("UHeightFogComponent_0");    
 }
+
+UObject* AHeightFogActor::Duplicate(UObject* InOuter)
+{
+    ThisClass* NewActor = Cast<ThisClass>(Super::Duplicate(InOuter));
+    NewActor->RootComponent = NewActor->GetComponentByFName<USceneComponent>(RootComponent->GetFName());
+
+    return NewActor;
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/HeightFogActor.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/HeightFogActor.h
@@ -10,6 +10,7 @@ class AHeightFogActor : public AActor
 
 public:
     AHeightFogActor();
+    UObject* Duplicate(UObject* InOuter);
 
     UHeightFogComponent* HeightFogComponent;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/PointLightActor.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/PointLightActor.cpp
@@ -18,3 +18,13 @@ APointLight::APointLight()
 APointLight::~APointLight()
 {
 }
+
+UObject* APointLight::Duplicate(UObject* InOuter)
+{
+    ThisClass* NewActor = Cast<ThisClass>(Super::Duplicate(InOuter));
+
+    NewActor->PointLightComponent = NewActor->GetComponentByFName<UPointLightComponent>(PointLightComponent->GetFName());
+    NewActor->BillboardComponent = NewActor->GetComponentByFName<UBillboardComponent>(BillboardComponent->GetFName());
+
+    return NewActor;
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/PointLightActor.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/PointLightActor.h
@@ -1,12 +1,12 @@
 #pragma once
 #include "LightActor.h"
-class APointLight :
-    public ALight
+class APointLight : public ALight
 {
     DECLARE_CLASS(APointLight, ALight)
 public:
     APointLight();
     virtual ~APointLight();
+    UObject* Duplicate(UObject* InOuter) override;
 protected:
     UPROPERTY
     (UPointLightComponent*, PointLightComponent, = nullptr);

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/SpotLightActor.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/SpotLightActor.cpp
@@ -17,3 +17,14 @@ ASpotLight::ASpotLight()
 ASpotLight::~ASpotLight()
 {
 }
+
+UObject* ASpotLight::Duplicate(UObject* InOuter)
+{
+    ThisClass* NewActor = Cast<ThisClass>(Super::Duplicate(InOuter));
+    
+    NewActor->SpotLightComponent = NewActor->GetComponentByFName<USpotLightComponent>(SpotLightComponent->GetFName());
+    NewActor->BillboardComponent = NewActor->GetComponentByFName<UBillboardComponent>(BillboardComponent->GetFName());
+
+
+    return NewActor;
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/SpotLightActor.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/SpotLightActor.h
@@ -7,6 +7,8 @@ class ASpotLight :
 public:
     ASpotLight();
     virtual ~ASpotLight();
+    UObject* Duplicate(UObject* InOuter) override;
+    
 protected:
     UPROPERTY
     (USpotLightComponent*, SpotLightComponent, = nullptr);

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/ActorComponent.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/ActorComponent.cpp
@@ -7,6 +7,7 @@ UObject* UActorComponent::Duplicate(UObject* InOuter)
 {
     ThisClass* NewComponent = Cast<ThisClass>(Super::Duplicate(InOuter));
 
+    NewComponent->SetFName(GetName());
     NewComponent->OwnerPrivate = OwnerPrivate;
     NewComponent->bIsActive = bIsActive;
     NewComponent->bAutoActive = bAutoActive;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/StaticMeshActor.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/StaticMeshActor.cpp
@@ -9,6 +9,15 @@ AStaticMeshActor::AStaticMeshActor()
     RootComponent = StaticMeshComponent;
 }
 
+UObject* AStaticMeshActor::Duplicate(UObject* InOuter)
+{
+    ThisClass* NewActor = Cast<ThisClass>(Super::Duplicate(InOuter));
+    
+    NewActor->RootComponent = NewActor->GetComponentByFName<USceneComponent>(RootComponent->GetFName());
+
+    return NewActor;
+}
+
 UStaticMeshComponent* AStaticMeshActor::GetStaticMeshComponent() const
 {
     return StaticMeshComponent;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/StaticMeshActor.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/StaticMeshActor.h
@@ -11,6 +11,8 @@ class AStaticMeshActor : public AActor
 public:
     AStaticMeshActor();
 
+    UObject* Duplicate(UObject* InOuter) override;
+
     UStaticMeshComponent* GetStaticMeshComponent() const;
 
 protected:

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/GameFramework/Actor.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/GameFramework/Actor.h
@@ -76,6 +76,10 @@ public:
         requires std::derived_from<T, UActorComponent>
     T* GetComponentByClass();
 
+    template<typename T>
+        requires std::derived_from<T, UActorComponent>
+    T* GetComponentByFName(FName InName);
+
     void InitializeComponents();
     void UninitializeComponents();
 
@@ -156,6 +160,22 @@ T* AActor::GetComponentByClass()
         if (T* CastedComponent = Cast<T>(Component))
         {
             return CastedComponent;
+        }
+    }
+    return nullptr;
+}
+
+template <typename T> requires std::derived_from<T, UActorComponent>
+T* AActor::GetComponentByFName(FName InName)
+{
+    for (UActorComponent* Component : OwnedComponents)
+    {
+        if (T* CastedComponent = Cast<T>(Component))
+        {
+            if (CastedComponent->GetFName() == InName)
+            {
+                return CastedComponent;
+            }
         }
     }
     return nullptr;

--- a/EngineSIU/EngineSIU/Shaders/Light.hlsl
+++ b/EngineSIU/EngineSIU/Shaders/Light.hlsl
@@ -105,7 +105,7 @@ float CalculateSpecular(float3 WorldNormal, float3 ToLightDir, float3 ViewDir, f
     return Spec * SpecularStrength;
 }
 
-float4 PointLight(int Index, float3 WorldPosition, float3 WorldNormal, float WorldViewPosition, float3 DiffuseColor)
+float4 PointLight(int Index, float3 WorldPosition, float3 WorldNormal, float3 WorldViewPosition, float3 DiffuseColor)
 {
     FPointLightInfo LightInfo = PointLights[Index];
     


### PR DESCRIPTION
## 주요 변경사항

- SetFName 추가
### AActor 상속 시 생성자에서 Component를 추가하는 경우
- 해당 Component를 GetComponentByFName으로 찾아와 넣어줘야 된다. (부모 자식 관계는 자동으로 넣어진다)
![image](https://github.com/user-attachments/assets/9f1aaac3-a5a4-4661-b69f-de9ffd3ad2ee)
![image](https://github.com/user-attachments/assets/289ee76b-fbca-4205-be7f-4e0246f86ddc)
