### PR TITLE
Feature/real point light

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/UnrealClient.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/UnrealClient.cpp
@@ -218,6 +218,7 @@ HRESULT FViewportResource::CreateShadowDepthStencilResource(EShadowDepthType Typ
 
     if (Type == EShadowDepthType::ESDT_Point)
     {
+        // Texture2D 생성
         D3D11_TEXTURE2D_DESC TextureDesc;
         ZeroMemory(&TextureDesc, sizeof(D3D11_TEXTURE2D_DESC));
         // TODO : Widht, Height Viewprot아닌 다른 사이즈로 하면 RTV도 수정 요함.
@@ -234,6 +235,7 @@ HRESULT FViewportResource::CreateShadowDepthStencilResource(EShadowDepthType Typ
         TextureDesc.MiscFlags = D3D11_RESOURCE_MISC_TEXTURECUBE;
         NewResource.Texture2D = FEngineLoop::GraphicDevice.CreateTexture2D(TextureDesc, nullptr);
     
+        // DSV 6개 생성
         D3D11_DEPTH_STENCIL_VIEW_DESC DSVDesc;
         ZeroMemory(&DSVDesc, sizeof(D3D11_DEPTH_STENCIL_VIEW_DESC));
         DSVDesc.Format = DXGI_FORMAT_D32_FLOAT;
@@ -253,6 +255,7 @@ HRESULT FViewportResource::CreateShadowDepthStencilResource(EShadowDepthType Typ
             }
         }
     
+        // 샘플용 SRV 생성
         D3D11_SHADER_RESOURCE_VIEW_DESC SRVDesc;
         ZeroMemory(&SRVDesc, sizeof(D3D11_SHADER_RESOURCE_VIEW_DESC));
         SRVDesc.Format = DXGI_FORMAT_R32_FLOAT;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/FShadowRenderPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/FShadowRenderPass.cpp
@@ -258,6 +258,7 @@ void FShadowRenderPass::Render(const std::shared_ptr<FEditorViewportClient>& Vie
 
     for (; LightIndex < DirectionalLights.Num(); LightIndex++)
     {
+        // Directional
         auto TargetIndex = LightIndex;
     
         PrepareRenderState(Viewport, EShadowDepthType::ESDT_Directional, TargetIndex);    
@@ -267,7 +268,8 @@ void FShadowRenderPass::Render(const std::shared_ptr<FEditorViewportClient>& Vie
 
     for (; LightIndex < DirectionalLights.Num() + PointLights.Num(); LightIndex++)
     {
-        auto TargetIndex = LightIndex - (DirectionalLights.Num());
+        // PointLight
+        auto TargetIndex = (LightIndex - (DirectionalLights.Num())) * 6;
         for (int32 i = 0; i < 6; i++)
         {
             PrepareRenderState(Viewport, EShadowDepthType::ESDT_Point, TargetIndex + i);    
@@ -278,6 +280,7 @@ void FShadowRenderPass::Render(const std::shared_ptr<FEditorViewportClient>& Vie
     
     for (; LightIndex < DirectionalLights.Num() + PointLights.Num() + SpotLights.Num(); LightIndex++)
     {
+        // SpotLight
         auto TargetIndex = LightIndex - (DirectionalLights.Num() + PointLights.Num());
     
         PrepareRenderState(Viewport, EShadowDepthType::ESDT_Spot, TargetIndex);    

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/UpdateLightBufferPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/UpdateLightBufferPass.cpp
@@ -182,6 +182,39 @@ FPointLightInfo FUpdateLightBufferPass::GetPointLightInfo(const UPointLightCompo
 {
     FPointLightInfo LightInfo = {};
 
+    FVector lightPos = LightComp->GetWorldLocation();
+
+    // 6면 방향 벡터
+    FVector targets[6] = {
+        {+1, 0, 0}, {-1, 0, 0},
+        {0, +1, 0}, {0, -1, 0},
+        {0, 0, +1}, {0, 0, -1}
+    };
+    // 각 면에 맞는 up 벡터 (Y+, Y+, Z-, Z+, Y+, Y+)
+    FVector ups[6] = {
+        {0, 1, 0}, {0, 1, 0},
+        {0, 0, -1},{0, 0, +1},
+        {0, 1, 0}, {0, 1, 0}
+    };
+
+    // face 별 뷰 행렬 구하기
+    FMatrix viewMats[6];
+    for (int face = 0; face < 6; ++face)
+    {
+        FVector eye = lightPos;
+        FVector target = lightPos + targets[face];
+        FVector up = ups[face];
+
+        viewMats[face] = JungleMath::CreateViewMatrix(eye, target, up);
+        LightInfo.View[face] = viewMats[face];
+    }
+
+    float fov = FMath::DegreesToRadians(90);
+    float aspect = 1;
+    float nearPlane = 0.01;
+    float farPlane = LightComp->GetRadius();
+
+    LightInfo.Projection = JungleMath::CreateProjectionMatrix(fov, aspect, nearPlane, farPlane);
     LightInfo.LightColor = LightComp->GetLightColor();
     LightInfo.Position = LightComp->GetWorldLocation();
     LightInfo.Radius = LightComp->GetRadius();

--- a/EngineSIU/EngineSIU/Shaders/Light.hlsl
+++ b/EngineSIU/EngineSIU/Shaders/Light.hlsl
@@ -232,7 +232,7 @@ float GetLightFromShadowMap(float3 WorldPosition, uint LightIndex)
     
     //bool IsInX = ShadowMapTexCoord.x < 0 || ShadowMapTexCoord.x > 1;
     //bool IsInY = ShadowMapTexCoord.y < 0 || ShadowMapTexCoord.y > 1;
-    
+  
     //float LightDistance = LightClipSpacePos.z / LightClipSpacePos.w;
     
     //if (IsInX || IsInY || LightDistance > 1)
@@ -247,30 +247,44 @@ float GetLightFromShadowMap(float3 WorldPosition, uint LightIndex)
     
     if (bIsPoint)
     {
-        float ShadowSum = 0;
-        for (int i = 0; i < 6; i++)
-        {            
-            float3 LightPosition = PointLights[TargetIndex].Position;
+         // PointLight 정보
+        FPointLightInfo p = PointLights[TargetIndex];
+        float3 LightPosition = p.Position;
+        //float  bias = 0.001f;          // 샘플 바이어스
 
-            float3 LightToPixelDirVector = normalize(WorldPosition - LightPosition);
-            
-            LightViewMatrix = PointLights[TargetIndex].ViewMatrix[i];
-            LightProjectionMatrix = PointLights[TargetIndex].ProjectionMatrix;
+        // 월드 위치 동차 좌표로 변경
+        float4 WorldPosition4 = float4(WorldPosition, 1.0f);
 
-            float4 LightViewPos = mul(float4(WorldPosition, 1.0f), LightViewMatrix);
-            float4 LightClipSpacePos = mul(LightViewPos, LightProjectionMatrix);
+        // 방향 벡터 (큐브맵 샘플할 좌표)
+        float3 LightDirection = normalize(WorldPosition - LightPosition);
 
-            float LightDistance = LightClipSpacePos.z / LightClipSpacePos.w;
-            LightDistance -= bias;
+        // 어떤 face를 쓸지 (GPU가 큐브맵 샘플링할 때와 동일한 규칙)
+        float3 LightDirectionAbs = abs(LightDirection);                // 절대값 각 축 크기 구함.
+        int   face;
+        if (LightDirectionAbs.x >= LightDirectionAbs.y && LightDirectionAbs.x >= LightDirectionAbs.z) 
+            face = LightDirection.x > 0 ? 0 : 1;   // +X, -X
+        else if (LightDirectionAbs.y >= LightDirectionAbs.z)
+            face = LightDirection.y > 0 ? 2 : 3;   // +Y, -Y
+        else
+            face = LightDirection.z > 0 ? 4 : 5;   // +Z, -Z
 
-            // 큐브맵 샘플링
-            ShadowSum += PointShadowMap.SampleCmpLevelZero(
-                ShadowSampler,
-                float4(LightToPixelDirVector, TargetIndex), // 텍스처 좌표 + TargetIndex
-                LightDistance
-            ).r;
-        }
-        Result = ShadowSum / 6.0f;
+        // ClipSpace 깊이 계산
+        float4 LightViewPos = mul(WorldPosition4, p.ViewMatrix[face]);        // 월드 → 라이트(큐브 face) 공간
+        float4 clipPos = mul(LightViewPos, p.ProjectionMatrix);   // 라이트 공간 -> Clip space
+
+        //FIXME : bias 적용
+        // NDC 깊이 (0~1) 추출
+        //float refDepth = clipPos.z / clipPos.w - bias;
+        float refDepth = clipPos.z / clipPos.w;
+
+        // SampleCmpLevelZero 으로 비교
+        float shadow = PointShadowMap.SampleCmpLevelZero(
+            ShadowSampler,
+            float4(LightDirection, TargetIndex),  // dir.xyzw: (방향벡터, 큐브맵 array 인덱스)
+            refDepth
+        ).r;
+
+        Result = shadow;
     }
     else
     {


### PR DESCRIPTION
## 주요 변경사항


![pointlight](https://github.com/user-attachments/assets/89d87f1c-066b-489d-bc4d-eec88c703ea4)
- PointLight face 별 뷰행렬, perspective 행렬 구하기
-- View 행렬 (eye = lightPosition, target= lightPos + (해당 face의 upvector), up = 해당 face의 up)
-- perspective 행렬( fov = 90도 , ratio = 1, farPlane = pointLIght Raidus, nearPlane = 0.01)

- 다중 포인트 라이트 쉐도우 이상한 버그 고침
-- 6면체로 인해 targetIndex연산에 6곱하기 추가


## TODO
- point Light bias 적용
- point Light ShadowMap ui 로 찍기
