### PR TITLE
fix : directionalLight eyePos 원점(0, 0, 0) -> Camera Location으로 변경

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/UpdateLightBufferPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/UpdateLightBufferPass.cpp
@@ -13,6 +13,7 @@
 #include "GameFramework/Actor.h"
 #include "Math/JungleMath.h"
 #include "UObject/UObjectIterator.h"
+#include "Editor/UnrealEd/EditorViewportClient.h"
 
 //------------------------------------------------------------------------------
 // 생성자/소멸자
@@ -65,7 +66,7 @@ void FUpdateLightBufferPass::PrepareRender()
 
 void FUpdateLightBufferPass::Render(const std::shared_ptr<FEditorViewportClient>& Viewport)
 {
-    UpdateLightBuffer();
+    UpdateLightBuffer(Viewport);
 }
 
 void FUpdateLightBufferPass::ClearRenderArr()
@@ -77,7 +78,7 @@ void FUpdateLightBufferPass::ClearRenderArr()
 }
 
 
-void FUpdateLightBufferPass::UpdateLightBuffer() const
+void FUpdateLightBufferPass::UpdateLightBuffer(const std::shared_ptr<FEditorViewportClient>& Viewport) const
 {
     TArray<FDirectionalLightInfo> DirectionalLightInfo = {};
     TArray<FAmbientLightInfo> AmbientLightInfo = {};
@@ -86,7 +87,7 @@ void FUpdateLightBufferPass::UpdateLightBuffer() const
 
     for (UDirectionalLightComponent* Light : DirectionalLights)
     {
-        DirectionalLightInfo.Add(GetDirectionalLightInfo(Light));
+        DirectionalLightInfo.Add(GetDirectionalLightInfo(Light, Viewport));
     }
 
     for (UAmbientLightComponent* Light : AmbientLights)
@@ -141,12 +142,13 @@ FAmbientLightInfo FUpdateLightBufferPass::GetAmbientLightInfo(const UAmbientLigh
     return LightInfo;
 }
 
-FDirectionalLightInfo FUpdateLightBufferPass::GetDirectionalLightInfo(const UDirectionalLightComponent* LightComp) const
+FDirectionalLightInfo FUpdateLightBufferPass::GetDirectionalLightInfo(const UDirectionalLightComponent* LightComp, const std::shared_ptr<FEditorViewportClient>& Viewport) const
 {
     FDirectionalLightInfo LightInfo = {};
     
     //씬 바운딩 스피어 정보
-    FVector sceneCenter = FVector(0, 0, 0);
+    //FVector sceneCenter = FVector(0, 0, 0);
+    FVector sceneCenter = FVector(Viewport->GetCameraLocation());
     float sphereRadius = 100.0f;
 
     // 라이트 방향 벡터 가져와 단위화 및 반전

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/UpdateLightBufferPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/UpdateLightBufferPass.h
@@ -28,11 +28,11 @@ public:
     virtual void PrepareRender() override;
     virtual void Render(const std::shared_ptr<FEditorViewportClient>& Viewport) override;
     virtual void ClearRenderArr() override;
-    void UpdateLightBuffer() const;
+    void UpdateLightBuffer(const std::shared_ptr<FEditorViewportClient>& Viewport) const;
 
 private:
     FAmbientLightInfo GetAmbientLightInfo(const UAmbientLightComponent* LightComp) const;
-    FDirectionalLightInfo GetDirectionalLightInfo(const UDirectionalLightComponent* LightComp) const;
+    FDirectionalLightInfo GetDirectionalLightInfo(const UDirectionalLightComponent* LightComp, const std::shared_ptr<FEditorViewportClient>& Viewport) const;
     FPointLightInfo GetPointLightInfo(const UPointLightComponent* LightComp) const;
     FSpotLightInfo GetSpotLightInfo(const USpotLightComponent* LightComp) const;
     FShadowInfo GetShadowInfo(const ULightComponent* LightComp) const;


### PR DESCRIPTION
## 주요 변경사항

https://github.com/user-attachments/assets/68d8f5da-d4d8-45b3-a5e0-34a37c31a08d



- eyePos 원점 변경
directional cascaded 적용시키기 전에 임의로 원점(0, 0, 0)쓰던 걸 카메라 위치로 사용하도록 변경하였습니다.
- worldPosition과 상관 없이 카메라와 위치가 멀어지면 그림자가 잘립니다.

- 이에 따라 visualize shadow map도 카메라 위치에 영향을 받고 있습니다


## TODO
- 카메라 위치를 받아오기 위해 어쩔 수 없이 viewport 정보를 계속 함수 인자로 넘겨주는 구조 변경이 필요 합니다.
- 해상도 개선을 위해 필터 설정을 수정 결과에 따라 cascaded shadow map 적용해볼 예정입니다.